### PR TITLE
Enable initialization of the perp class with either wallet keypair or wallet address

### DIFF
--- a/src/public/base.ts
+++ b/src/public/base.ts
@@ -53,6 +53,7 @@ export class Perp {
   connection: Connection;
   program: Program;
   wallet: Wallet;
+  wallet_public_key: PublicKey;
   networkType: NetworkType;
   ADDRESSES: ConstantIDs;
 
@@ -61,9 +62,21 @@ export class Perp {
     networkType: NetworkType,
     wallet?: Wallet,
     mpg?: MarketProductGroup,
-    mpgBytes?: Buffer
+    mpgBytes?: Buffer,
+    wallet_address?: PublicKey
   ) {
+    if (!wallet && !wallet_address) {
+        throw new Error(
+            "Either wallet or wallet_address must be provided"
+        );
+    }
+    if (wallet && wallet_address) {
+        throw new Error(
+            "Either wallet or wallet_address must be provided but not both"
+        );
+    }
     if (wallet) this.wallet = wallet;
+    this.wallet_public_key = wallet ? wallet.publicKey : wallet_address;
     const providerWallet = new Wallet(Keypair.generate())
     const provider = new AnchorProvider(
       connection,

--- a/src/public/product.ts
+++ b/src/public/product.ts
@@ -23,7 +23,9 @@ export class Product extends Perp {
       perp.connection,
       perp.networkType,
       perp.wallet,
-      perp.marketProductGroup
+      perp.marketProductGroup,
+      perp.mpgBytes,
+      perp.wallet_public_key
     );
   }
 

--- a/src/public/trader.ts
+++ b/src/public/trader.ts
@@ -43,7 +43,8 @@ export class Trader extends Perp {
       perp.networkType,
       perp.wallet,
       perp.marketProductGroup,
-      perp.mpgBytes
+      perp.mpgBytes,
+      perp.wallet_public_key
     );
     if (referralKey){
       this.referralKey = referralKey
@@ -78,7 +79,7 @@ export class Trader extends Perp {
       throw new Error("Please pass in your wallet in the Perp class constructor, or run the setWallet function in the Perp class to update your keypair")
     }
     const trgAddress = await getTrgAddress(
-      this.wallet,
+      this.wallet.publicKey,
       this.connection,
       this.ADDRESSES.DEX_ID,
       this.ADDRESSES.MPG_ID
@@ -162,10 +163,7 @@ export class Trader extends Perp {
   }
 
   async getAllTraderAddresses(): Promise<PublicKey[]> {
-    if (!this.wallet) {
-      throw new Error("Please pass in your wallet in the Perp class constructor, or run the setWallet function in the Perp class to update your keypair")
-    }
-    const addresses = await getTrgAllAddresses(this.wallet,
+    const addresses = await getTrgAllAddresses(this.wallet_public_key,
       this.connection,
       this.ADDRESSES.DEX_ID,
       this.ADDRESSES.MPG_ID)
@@ -173,11 +171,8 @@ export class Trader extends Perp {
   }
 
   async init() {
-    if (!this.wallet) {
-      throw new Error("Please pass in your wallet in the Perp class constructor, or run the setWallet function in the Perp class to update your keypair")
-    }
     const trgAddress = await getTrgAddress(
-      this.wallet,
+      this.wallet_public_key,
       this.connection,
       this.ADDRESSES.DEX_ID,
       this.ADDRESSES.MPG_ID
@@ -191,7 +186,7 @@ export class Trader extends Perp {
     this.trgBytes = res[1].data;
     this.traderRiskGroup = res![0];
     const userTokenAccount = await getUserAta(
-      this.wallet.publicKey,
+      this.wallet_public_key,
       this.ADDRESSES.VAULT_MINT
     );
     this.userTokenAccount = userTokenAccount;
@@ -213,6 +208,9 @@ export class Trader extends Perp {
       throw new Error(
         "Please run init() function first to initialise the trader state!"
       );
+    if (!this.wallet) {
+      throw new Error("Please pass in your wallet in the Perp class constructor, or run the setWallet function in the Perp class to update your keypair")
+    }
     const accounts = {
         owner: this.wallet.publicKey,
         traderRiskGroup: this.trgKey,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export type TraderPosition = {
 }
 
 export const getTrgAddress = async (
-  wallet: NodeWallet,
+  walletKey: PublicKey,
   connection: Connection,
   DEX_ID: PublicKey,
   MPG_ID: PublicKey
@@ -32,7 +32,7 @@ export const getTrgAddress = async (
           memcmp: {
             offset: 48,
             /** data to match, a base-58 encoded string and limited to less than 129 bytes */
-            bytes: wallet.publicKey.toBase58(),
+            bytes: walletKey.toBase58(),
           },
         },
         {
@@ -51,7 +51,7 @@ export const getTrgAddress = async (
 };
 
 export const getTrgAllAddresses = async (
-  wallet: NodeWallet,
+  walletKey: PublicKey,
   connection: Connection,
   DEX_ID: PublicKey,
   MPG_ID: PublicKey
@@ -67,7 +67,7 @@ export const getTrgAllAddresses = async (
           memcmp: {
             offset: 48,
             /** data to match, a base-58 encoded string and limited to less than 129 bytes */
-            bytes: wallet.publicKey.toBase58(),
+            bytes: walletKey.toBase58(),
           },
         },
         {


### PR DESCRIPTION
This enables users to do things like fetching open orders without needing to provide the entire wallet keypair.